### PR TITLE
ramips: use tpt DTS trigger for TP-Link TL-MR3020 v3 and TL-WA801ND v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -337,13 +337,9 @@ tplink,c50-v4)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
-tplink,tl-wa801nd-v5)
-	ucidef_set_led_wlan "wlan" "wlan" "$boardname:green:wlan" "phy0tpt"
-	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
-	;;
+tplink,tl-wa801nd-v5|\
 tplink,tl-mr3020-v3)
-	set_wifi_led "$boardname:green:wlan"
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v5|\
 tplink,tl-wr842n-v5)

--- a/target/linux/ramips/dts/TL-MR3020V3.dts
+++ b/target/linux/ramips/dts/TL-MR3020V3.dts
@@ -67,6 +67,7 @@
 		wlan {
 			label = "tl-mr3020-v3:green:wlan";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/TL-WA801NDV5.dts
+++ b/target/linux/ramips/dts/TL-WA801NDV5.dts
@@ -49,6 +49,7 @@
 		wlan {
 			label = "tl-wa801nd-v5:green:wlan";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps_red {


### PR DESCRIPTION
This converts the TP-Link TL-MR3020v3 board to use the WLAN throughput
LED trigger in order to react to all VAPs.

It also moves the WLAN trigger config of the TP-Link TL-WA801NDv5 to the
DTS and merges the now identical LAN LED configs.

Verified these changes on a TL-MR3020v3 and TL-WA801NDv5.

Signed-off-by: Jan Alexander <jan@nalx.net>
[changed commit title and extended commit message]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
[added comment about test result on TL-WA801ND v5]
Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 20eb45da4fc19c12ea2073471992eeaf9d602fa5)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
